### PR TITLE
Fix menu sizing and event cleanup

### DIFF
--- a/public/menu.html
+++ b/public/menu.html
@@ -10,13 +10,15 @@
       -webkit-app-region: no-drag; /* 确保可点击 */
     }
     .menu {
-      width: 150px;
+      display: inline-block;
+      min-width: 150px;
       background: rgba(255,255,255,0.95);
       border-radius: 6px;
       padding: 5px 0;
       font-family: sans-serif;
       user-select: none;
       border: 1px solid #ccc;
+      box-sizing: border-box; /* 让计算包含边框和内边距，避免出现滚动条 */
     }
     .item {
       padding: 0px 8px;
@@ -56,6 +58,12 @@
           }
           container.appendChild(div)
         })
+        // 将实际内容尺寸告知主进程，便于窗口适配
+        const size = {
+          width: container.offsetWidth,
+          height: container.offsetHeight
+        }
+        ipcRenderer.send('menu-size', size)
       })
     })
     // 额外防护：失焦后关闭

--- a/src/background.js
+++ b/src/background.js
@@ -251,6 +251,16 @@ ipcMain.on('show-floating-menu', (event, { x, y, items }) => {
   })
 })
 
+// 接收渲染进程发送的菜单尺寸，动态调整窗口大小
+ipcMain.on('menu-size', (event, { width: w, height: h }) => {
+  if (menuWindow && !menuWindow.isDestroyed()) {
+    const [x, y] = menuWindow.getPosition()
+    const width = Math.ceil(w)
+    const height = Math.ceil(h)
+    menuWindow.setBounds({ x, y, width, height })
+  }
+})
+
 // 子窗口点击后发回 'menu-command'，转发给主窗口
 ipcMain.on('menu-command', (event, command) => {
   if (mainWindow && !mainWindow.isDestroyed()) {

--- a/src/components/common/RightMenu.vue
+++ b/src/components/common/RightMenu.vue
@@ -111,12 +111,16 @@ export default {
   },
   mounted () {
     // 监听子窗口选择命令并转发出来
-    window.electronAPI.onMenuCommand((cmd) => {
+    this._removeMenuCommand = window.electronAPI.onMenuCommand((cmd) => {
       const selected = this.items.find(i => i.key === cmd)
       if (selected) {
         this.$emit('select', selected)
       }
     })
+  },
+  beforeDestroy () {
+    // 销毁组件时移除监听，避免重复触发
+    this._removeMenuCommand && this._removeMenuCommand()
   }
 }
 </script>

--- a/src/preload.js
+++ b/src/preload.js
@@ -53,7 +53,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return fs.existsSync(filePath);
   },
   showFloatingMenu: (options) => ipcRenderer.send('show-floating-menu', options),
-  onMenuCommand: (callback) => ipcRenderer.on('menu-command', (e, cmd) => callback(cmd))
+  onMenuCommand: (callback) => {
+    const handler = (e, cmd) => callback(cmd)
+    ipcRenderer.on('menu-command', handler)
+    return () => ipcRenderer.removeListener('menu-command', handler)
+  }
 });
 
 // 简易存储接口，使用同步 ipc 调用主进程持久化数据


### PR DESCRIPTION
## Summary
- compute actual floating menu size and update window
- remove overflow hidden and use box-sizing
- return unsubscribe for onMenuCommand in preload
- clean up listener in RightMenu

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d166afff08331a3f1668e1d3509a6