### PR TITLE
Fix duplicate conversation pinning

### DIFF
--- a/src/components/common/RightMenu.vue
+++ b/src/components/common/RightMenu.vue
@@ -98,7 +98,8 @@ export default {
   data () {
     return {
       pos: { x: 0, y: 0 },
-      items: []
+      items: [],
+      removeMenuCmd: null
     }
   },
   methods: {
@@ -106,17 +107,27 @@ export default {
       console.log(pos, items);
       this.pos = pos
       this.items = items
+      // 确保旧监听器被移除
+      if (this.removeMenuCmd) {
+        this.removeMenuCmd()
+        this.removeMenuCmd = null
+      }
+
+      // 监听一次菜单命令，执行后立即移除
+      this.removeMenuCmd = window.electronAPI.onMenuCommand((cmd) => {
+        const selected = this.items.find(i => i.key === cmd)
+        if (selected) {
+          this.$emit('select', selected)
+        }
+        this.removeMenuCmd && this.removeMenuCmd()
+        this.removeMenuCmd = null
+      })
+
       window.electronAPI.showFloatingMenu({ x: pos.screenX, y: pos.screenY, items })
     },
   },
-  mounted () {
-    // 监听子窗口选择命令并转发出来
-    window.electronAPI.onMenuCommand((cmd) => {
-      const selected = this.items.find(i => i.key === cmd)
-      if (selected) {
-        this.$emit('select', selected)
-      }
-    })
+  beforeDestroy () {
+    this.removeMenuCmd && this.removeMenuCmd()
   }
 }
 </script>

--- a/src/preload.js
+++ b/src/preload.js
@@ -53,7 +53,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return fs.existsSync(filePath);
   },
   showFloatingMenu: (options) => ipcRenderer.send('show-floating-menu', options),
-  onMenuCommand: (callback) => ipcRenderer.on('menu-command', (e, cmd) => callback(cmd))
+  onMenuCommand: (callback) => {
+    const handler = (e, cmd) => callback(cmd)
+    ipcRenderer.on('menu-command', handler)
+    return () => ipcRenderer.removeListener('menu-command', handler)
+  }
 });
 
 // 简易存储接口，使用同步 ipc 调用主进程持久化数据

--- a/src/view/Chat.vue
+++ b/src/view/Chat.vue
@@ -48,9 +48,9 @@
                      :index="index"
                      @click.native="onActiveItem(chat,index)"
                      @delete="onDelItem(index)"
-                     @top="onTop(index)"
+                     @top="onTop(chat)"
                      @info="onShowInfo(chat)"
-                     @unpinfromtop="unpinFromTop(index)"
+                     @unpinfromtop="unpinFromTop(chat)"
                      @heimingdan="blacklist"
                      @chakangerenxinxi="showFriendInfo"
                      :active="chat === chatStore.activeChat"></chat-item>
@@ -136,8 +136,9 @@ export default {
     onDelItem (index) {
       this.chatStore.removeChat(index);
     },
-    onTop (chatIdx) {
-      this.chatStore.moveTop(chatIdx);
+    onTop (chat) {
+      const idx = this.chatStore.findChatIdx(chat)
+      this.chatStore.moveTop(idx)
     },
     onShowInfo (chat) {
       if (chat.type == 'PRIVATE') {
@@ -150,8 +151,9 @@ export default {
         this.$router.push("/home/group?id=" + chat.targetId);
       }
     },
-    unpinFromTop (chatIdx) {
-      this.chatStore.unpinFromTop(chatIdx)
+    unpinFromTop (chat) {
+      const idx = this.chatStore.findChatIdx(chat)
+      this.chatStore.unpinFromTop(idx)
     },
     // 添加黑名单
     blacklist (item) {


### PR DESCRIPTION
## Summary
- keep chat item index fresh when pinning/unpinning chats
- emit chat object for pin/unpin
- return cleanup function from onMenuCommand
- register menu listener only when menu is open

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d242bd1e48331a478cf1c1ad90f08