### PR TITLE
Enable click jump to pinned group messages

### DIFF
--- a/src/components/chat/ChatTopMessage.vue
+++ b/src/components/chat/ChatTopMessage.vue
@@ -19,7 +19,8 @@
            ref="messages">
         <div class="title">置顶消息:</div>
         <div class="content"
-             v-html="content(item)">
+             v-html="content(item)"
+             @click.stop="onLocate(item)">
         </div>
         <div class="close"
              title="移除"
@@ -98,6 +99,9 @@ export default {
         url: "/group/hideTopMessage/" + this.group.id,
         method: 'delete'
       });
+    },
+    onLocate (item) {
+      this.$emit('locate', item);
     },
     content (value) {
       let content = "不支持的消息类型";


### PR DESCRIPTION
## Summary
- add click handler for group top messages
- emit `locate` event so chat can jump to original message

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ca435df883319b713d19e2f25e2f