### PR TITLE
Switch chat storage to SQLite

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "vue": "2.7.16",
     "vue-axios": "3.5.2",
     "vue-router": "3.6.5",
-    "vue-video-player": "^5.0.2"
+    "vue-video-player": "^5.0.2",
+    "sqlite3": "5.1.6"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.5.12",

--- a/src/preload.js
+++ b/src/preload.js
@@ -66,3 +66,10 @@ contextBridge.exposeInMainWorld('electronStore', {
   setItem: (key, value) => ipcRenderer.sendSync('store-set', { key, value }),
   removeItem: (key) => ipcRenderer.sendSync('store-remove', key)
 });
+
+// SQLite 持久化接口
+contextBridge.exposeInMainWorld('electronDB', {
+  getItem: (key) => ipcRenderer.invoke('db-get', key),
+  setItem: (key, value) => ipcRenderer.invoke('db-set', { key, value }),
+  removeItem: (key) => ipcRenderer.invoke('db-remove', key)
+});

--- a/src/utils/electronForage.js
+++ b/src/utils/electronForage.js
@@ -1,25 +1,24 @@
 import localForage from 'localforage'
 
-const isElectron = typeof window !== 'undefined' && window.electronStore
+// 在浏览器环境下使用 IndexedDB/WebSQL，本地应用则使用 SQLite
+const useElectronDB = typeof window !== 'undefined' && window.electronDB
 
 const electronForage = {
   setItem (key, value) {
-    if (isElectron) {
-      window.electronStore.setItem(key, value)
-      return Promise.resolve(value)
+    if (useElectronDB) {
+      return window.electronDB.setItem(key, value)
     }
     return localForage.setItem(key, value)
   },
   getItem (key) {
-    if (isElectron) {
-      return Promise.resolve(window.electronStore.getItem(key))
+    if (useElectronDB) {
+      return window.electronDB.getItem(key)
     }
     return localForage.getItem(key)
   },
   removeItem (key) {
-    if (isElectron) {
-      window.electronStore.removeItem(key)
-      return Promise.resolve()
+    if (useElectronDB) {
+      return window.electronDB.removeItem(key)
     }
     return localForage.removeItem(key)
   }


### PR DESCRIPTION
## Summary
- add `sqlite3` dependency
- use SQLite database in Electron via new IPC handlers
- expose `electronDB` API in preload script
- have `electronForage` use SQLite when available

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e7cbe8988331b9a5f2cc0199eab8