### PR TITLE
Implement Jitsi meeting page with close control

### DIFF
--- a/public/jitsi.html
+++ b/public/jitsi.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Jitsi Meeting</title>
+  <style>
+    html,body,#jitsi-container{
+      width:100%;
+      height:100%;
+      margin:0;
+      padding:0;
+      overflow:hidden;
+    }
+    #closeBtn{
+      position:absolute;
+      top:10px;
+      right:10px;
+      z-index:1000;
+      width:32px;
+      height:32px;
+      line-height:32px;
+      text-align:center;
+      border-radius:16px;
+      background:rgba(0,0,0,0.5);
+      color:#fff;
+      cursor:pointer;
+      font-size:18px;
+    }
+  </style>
+</head>
+<body>
+  <div id="jitsi-container"></div>
+  <div id="closeBtn">&#10005;</div>
+  <script src="https://meet.jit.si/external_api.js"></script>
+  <script>
+    (function(){
+      const params=new URLSearchParams(location.search);
+      const url=params.get('url');
+      const container=document.getElementById('jitsi-container');
+      let api=null;
+      if(url){
+        const a=document.createElement('a');
+        a.href=url;
+        const domain=a.host;
+        let room=a.pathname.replace(/^\//,'');
+        const search=new URLSearchParams(a.search);
+        const options={roomName:room,parentNode:container};
+        if(search.get('jwt')) options.jwt=search.get('jwt');
+        api=new JitsiMeetExternalAPI(domain,options);
+        api.addListener('readyToClose',()=>{window.close();});
+      }else{
+        container.innerHTML='Invalid meeting url';
+      }
+      document.getElementById('closeBtn').onclick=function(){
+        if(api){api.executeCommand('hangup');}
+        window.close();
+      };
+      window.addEventListener('beforeunload',()=>{if(api) api.dispose();});
+    })();
+  </script>
+</body>
+</html>

--- a/public/jitsi.html
+++ b/public/jitsi.html
@@ -4,33 +4,55 @@
   <meta charset="UTF-8">
   <title>Jitsi Meeting</title>
   <style>
-    html,body,#jitsi-container{
+    html,body{
       width:100%;
       height:100%;
       margin:0;
       padding:0;
       overflow:hidden;
     }
-    #closeBtn{
+    #titlebar{
       position:absolute;
-      top:10px;
-      right:10px;
-      z-index:1000;
-      width:32px;
+      top:0;
+      left:0;
+      right:0;
       height:32px;
-      line-height:32px;
-      text-align:center;
-      border-radius:16px;
-      background:rgba(0,0,0,0.5);
+      background:rgba(0,0,0,0.7);
       color:#fff;
+      display:flex;
+      align-items:center;
+      padding:0 8px;
+      box-sizing:border-box;
+      cursor:move;
+      user-select:none;
+    }
+    #titlebar .btn{
+      width:24px;
+      height:24px;
+      line-height:24px;
+      text-align:center;
+      border-radius:4px;
+      margin-left:4px;
       cursor:pointer;
-      font-size:18px;
+      background:rgba(255,255,255,0.2);
+      font-size:14px;
+    }
+    #jitsi-container{
+      position:absolute;
+      top:32px;
+      left:0;
+      right:0;
+      bottom:0;
     }
   </style>
 </head>
 <body>
+  <div id="titlebar">
+    <div style="flex:1;">Jitsi Meeting</div>
+    <div id="maxBtn" class="btn">&#9723;</div>
+    <div id="closeBtn" class="btn">&#10005;</div>
+  </div>
   <div id="jitsi-container"></div>
-  <div id="closeBtn">&#10005;</div>
   <script src="https://meet.jit.si/external_api.js"></script>
   <script>
     (function(){
@@ -38,6 +60,8 @@
       const url=params.get('url');
       const container=document.getElementById('jitsi-container');
       let api=null;
+      let isMax=false;
+      let restorePos=null;
       if(url){
         const a=document.createElement('a');
         a.href=url;
@@ -51,10 +75,36 @@
       }else{
         container.innerHTML='Invalid meeting url';
       }
-      document.getElementById('closeBtn').onclick=function(){
+      const closeBtn=document.getElementById('closeBtn');
+      const maxBtn=document.getElementById('maxBtn');
+      closeBtn.onclick=function(){
         if(api){api.executeCommand('hangup');}
         window.close();
       };
+      maxBtn.onclick=function(){
+        if(!isMax){
+          restorePos={w:window.outerWidth,h:window.outerHeight,x:window.screenX,y:window.screenY};
+          window.moveTo(0,0);
+          window.resizeTo(screen.availWidth,screen.availHeight);
+        }else if(restorePos){
+          window.moveTo(restorePos.x,restorePos.y);
+          window.resizeTo(restorePos.w,restorePos.h);
+        }
+        isMax=!isMax;
+      };
+      const bar=document.getElementById('titlebar');
+      let dragging=false,startX=0,startY=0;
+      bar.addEventListener('mousedown',e=>{
+        if(e.target===closeBtn||e.target===maxBtn)return;
+        dragging=true;startX=e.screenX;startY=e.screenY;
+      });
+      window.addEventListener('mousemove',e=>{
+        if(dragging){
+          window.moveBy(e.screenX-startX,e.screenY-startY);
+          startX=e.screenX;startY=e.screenY;
+        }
+      });
+      window.addEventListener('mouseup',()=>{dragging=false;});
       window.addEventListener('beforeunload',()=>{if(api) api.dispose();});
     })();
   </script>

--- a/src/components/chat/ChatConferenceCard.vue
+++ b/src/components/chat/ChatConferenceCard.vue
@@ -35,7 +35,7 @@ export default {
         const height = Math.floor(window.screen.availHeight * 0.8)
         const left = Math.floor((window.screen.availWidth - width) / 2)
         const top = Math.floor((window.screen.availHeight - height) / 2)
-        const features = `width=${width},height=${height},left=${left},top=${top},resizable=yes`
+        const features = `width=${width},height=${height},left=${left},top=${top},resizable=yes,menubar=no,location=no,status=no,toolbar=no`
         window.open(`/jitsi.html?url=${meetUrl}`, '_blank', features)
       })
     },

--- a/src/components/chat/ChatConferenceCard.vue
+++ b/src/components/chat/ChatConferenceCard.vue
@@ -31,7 +31,12 @@ export default {
         method: 'GET'
       }).then(url => {
         const meetUrl = encodeURIComponent(url)
-        window.open(`/jitsi.html?url=${meetUrl}`)
+        const width = Math.floor(window.screen.availWidth * 0.8)
+        const height = Math.floor(window.screen.availHeight * 0.8)
+        const left = Math.floor((window.screen.availWidth - width) / 2)
+        const top = Math.floor((window.screen.availHeight - height) / 2)
+        const features = `width=${width},height=${height},left=${left},top=${top},resizable=yes`
+        window.open(`/jitsi.html?url=${meetUrl}`, '_blank', features)
       })
     },
   },

--- a/src/components/chat/ChatConferenceCard.vue
+++ b/src/components/chat/ChatConferenceCard.vue
@@ -30,7 +30,8 @@ export default {
         url: `/jitsi/meet/auth/${this.groupInfo.id}`,
         method: 'GET'
       }).then(url => {
-        window.open(url)
+        const meetUrl = encodeURIComponent(url)
+        window.open(`/jitsi.html?url=${meetUrl}`)
       })
     },
   },


### PR DESCRIPTION
## Summary
- support Jitsi meeting with page-level close button
- open meetings via new `jitsi.html` wrapper

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_687102358d608331bfd3c675efaeb5fc