### PR TITLE
Fix download icon for forwarded files

### DIFF
--- a/src/components/chat/ChatForwardMessage.vue
+++ b/src/components/chat/ChatForwardMessage.vue
@@ -104,8 +104,16 @@ export default {
         return this.userInfo
       } else if (this.isFriend) {
         return this.friendInfo
-      } else if (!this.isFriend) {
-        return { nickName: this.groupMemberInfo.showNickName, headImage: this.groupMemberInfo.headImage }
+      } else if (this.groupMemberInfo) {
+        return {
+          nickName: this.groupMemberInfo.showNickName,
+          headImage: this.groupMemberInfo.headImage
+        }
+      } else {
+        return {
+          nickName: this.content.sendNickName || '',
+          headImage: ''
+        }
       }
     },
   },

--- a/src/components/chat/ChatForwardMessage.vue
+++ b/src/components/chat/ChatForwardMessage.vue
@@ -33,9 +33,10 @@
         <div class="file-box">
           <div class="file-info">
             <div class="file-icon">
-              <!-- 使用转发消息本身，但内容需解包为文件数据 -->
-              <downloadFile :msgInfo="forwardFileMsg"
-                            :chat="chat" />
+              <!-- 传入原始转发消息，由 downloadFile 识别 isForward -->
+              <downloadFile :msgInfo="cardInfo"
+                            :chat="chat"
+                            :isForward="true" />
             </div>
             <div class="file-text">
               <p class="file-text-name">{{ JSON.parse(content.content).name}}</p>
@@ -126,11 +127,6 @@ export default {
     },
     groupMemberInfo () {
       return this.groupMembers.find((f) => f.userId == this.content.sendId);
-    },
-    // 将转发消息转换为文件消息格式，保持下载逻辑一致
-    forwardFileMsg () {
-      const inner = JSON.parse(this.cardInfo.content);
-      return { ...this.cardInfo, content: inner.content };
     },
     forwardTip () {
       let html = `<div style="display: flex;justify-content: flex-start;align-items: center;">转发自用户<img style="width: 30px;height: 30px;border-radius: 15px;margin:0 3px;" src="${this.isSentIt().headImage}" />${this.isSentIt().nickName}</div>`

--- a/src/components/chat/ChatForwardMessage.vue
+++ b/src/components/chat/ChatForwardMessage.vue
@@ -33,9 +33,9 @@
         <div class="file-box">
           <div class="file-info">
             <div class="file-icon">
-              <downloadFile :msgInfo="content"
-                            :chat="chat"
-                            :id="content.id" />
+              <!-- 使用转发消息本身作为 msgInfo，保持与文件消息一致的下载状态逻辑 -->
+              <downloadFile :msgInfo="cardInfo"
+                            :chat="chat" />
             </div>
             <div class="file-text">
               <p class="file-text-name">{{ JSON.parse(content.content).name}}</p>

--- a/src/components/chat/ChatForwardMessage.vue
+++ b/src/components/chat/ChatForwardMessage.vue
@@ -33,8 +33,8 @@
         <div class="file-box">
           <div class="file-info">
             <div class="file-icon">
-              <!-- 使用转发消息本身作为 msgInfo，保持与文件消息一致的下载状态逻辑 -->
-              <downloadFile :msgInfo="cardInfo"
+              <!-- 使用转发消息本身，但内容需解包为文件数据 -->
+              <downloadFile :msgInfo="forwardFileMsg"
                             :chat="chat" />
             </div>
             <div class="file-text">
@@ -126,6 +126,11 @@ export default {
     },
     groupMemberInfo () {
       return this.groupMembers.find((f) => f.userId == this.content.sendId);
+    },
+    // 将转发消息转换为文件消息格式，保持下载逻辑一致
+    forwardFileMsg () {
+      const inner = JSON.parse(this.cardInfo.content);
+      return { ...this.cardInfo, content: inner.content };
     },
     forwardTip () {
       let html = `<div style="display: flex;justify-content: flex-start;align-items: center;">转发自用户<img style="width: 30px;height: 30px;border-radius: 15px;margin:0 3px;" src="${this.isSentIt().headImage}" />${this.isSentIt().nickName}</div>`


### PR DESCRIPTION
## Summary
- ensure forwarded file messages use the same icon logic as regular files

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874d335ac8083318e836226cdf7d3f3